### PR TITLE
Make autocomplete value a prop

### DIFF
--- a/docs/gitbook/Api/Props.md
+++ b/docs/gitbook/Api/Props.md
@@ -35,6 +35,16 @@ disabled: {
 },
 
 /**
+ * Value of the 'autocomplete' field of the input
+ * element.
+ * @type {String}
+ */
+autocomplete: {
+  type: String,
+  default: 'off'
+},
+
+/**
  * Sets the max-height property on the dropdown list.
  * @deprecated
  * @type {String}

--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -336,7 +336,7 @@
                 @focus="onSearchFocus"
                 type="search"
                 class="form-control"
-                autocomplete="off"
+                :autocomplete="autocomplete"
                 :disabled="disabled"
                 :placeholder="searchPlaceholder"
                 :tabindex="tabindex"
@@ -510,6 +510,17 @@
       label: {
         type: String,
         default: 'label'
+      },
+
+
+      /**
+       * Value of the 'autocomplete' field of the input
+       * element.
+       * @type {String}
+       */
+      autocomplete: {
+        type: String,
+        default: 'off'
       },
 
       /**


### PR DESCRIPTION
What
---
- Turn the autocomplete value on the `input` configurable by exposing it
as a prop.

Why
---
So it can be customised, which can be necessary to help developers show
or hide autocomplete forms as they wish.